### PR TITLE
chore: update version to 0.0.9 and improve version bump logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,19 +72,32 @@ jobs:
           if [ -z "$BUMP_TYPE" ]; then
             echo "Determining version bump from commit messages..."
             
-            # Get commit messages since last release
-            COMMIT_MESSAGES=$(git log --pretty=format:"%s" HEAD~10..HEAD)
+            # Get commit messages since last tag (or all commits if no tags exist)
+            LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+            if [ -n "$LAST_TAG" ]; then
+              echo "Getting commits since last tag: $LAST_TAG"
+              COMMIT_MESSAGES=$(git log --pretty=format:"%s" "$LAST_TAG"..HEAD)
+            else
+              echo "No previous tags found, analyzing all commits"
+              COMMIT_MESSAGES=$(git log --pretty=format:"%s")
+            fi
             echo "Recent commit messages:"
             echo "$COMMIT_MESSAGES"
             
-            # Check for breaking changes (major bump)
-            if echo "$COMMIT_MESSAGES" | grep -i "BREAKING CHANGE\|breaking:" > /dev/null; then
-              BUMP_TYPE="major"
-            # Check for features (minor bump)
-            elif echo "$COMMIT_MESSAGES" | grep -E "^feat(\(.+\))?:" > /dev/null; then
-              BUMP_TYPE="minor"
-            # Default to patch bump for fixes and other changes
+            # Analyze commit messages if any exist
+            if [ -n "$COMMIT_MESSAGES" ]; then
+              # Check for breaking changes (major bump)
+              if echo "$COMMIT_MESSAGES" | grep -i "BREAKING CHANGE\|breaking:" > /dev/null; then
+                BUMP_TYPE="major"
+              # Check for features (minor bump)
+              elif echo "$COMMIT_MESSAGES" | grep -E "^feat(\(.+\))?:" > /dev/null; then
+                BUMP_TYPE="minor"
+              # Default to patch bump for fixes and other changes
+              else
+                BUMP_TYPE="patch"
+              fi
             else
+              echo "No commit messages found, defaulting to patch bump"
               BUMP_TYPE="patch"
             fi
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@ temp**
 tmp**
 
 .env
-
-test-*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "contract-deployer"
-version = "1.0.0"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-deployer"
-version = "1.0.0"
+version = "0.0.9"
 edition = "2024"
 authors = ["David <0xdavid7@proton.me>"]
 description = "Automated deployment tool for Foundry-based repositories"

--- a/scripts/test-version-logic.sh
+++ b/scripts/test-version-logic.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Test script to validate the version bump logic
+set -e
+
+echo "🧪 Testing version bump logic..."
+echo ""
+
+# Get current version from Cargo.toml
+CURRENT_VERSION=$(grep "^version = " Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+echo "📦 Current version: $CURRENT_VERSION"
+
+# Parse version components
+MAJOR=$(echo $CURRENT_VERSION | cut -d. -f1)
+MINOR=$(echo $CURRENT_VERSION | cut -d. -f2)
+PATCH=$(echo $CURRENT_VERSION | cut -d. -f3)
+echo "🔍 Parsed version: MAJOR=$MAJOR, MINOR=$MINOR, PATCH=$PATCH"
+echo ""
+
+# Get commit messages since last tag
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [ -n "$LAST_TAG" ]; then
+  echo "🏷️  Getting commits since last tag: $LAST_TAG"
+  COMMIT_MESSAGES=$(git log --pretty=format:"%s" "$LAST_TAG"..HEAD)
+else
+  echo "🏷️  No previous tags found, analyzing all commits"
+  COMMIT_MESSAGES=$(git log --pretty=format:"%s")
+fi
+
+echo "📝 Recent commit messages:"
+echo "$COMMIT_MESSAGES"
+echo ""
+
+# Determine bump type
+if [ -n "$COMMIT_MESSAGES" ]; then
+  if echo "$COMMIT_MESSAGES" | grep -i "BREAKING CHANGE\|breaking:" > /dev/null; then
+    BUMP_TYPE="major"
+    echo "💥 Found breaking changes - MAJOR bump"
+  elif echo "$COMMIT_MESSAGES" | grep -E "^feat(\(.+\))?:" > /dev/null; then
+    BUMP_TYPE="minor"
+    echo "✨ Found feature commits - MINOR bump"
+  else
+    BUMP_TYPE="patch"
+    echo "🔧 Default - PATCH bump"
+  fi
+else
+  echo "❓ No commit messages found, defaulting to PATCH bump"
+  BUMP_TYPE="patch"
+fi
+
+echo ""
+echo "📈 Version bump type: $BUMP_TYPE"
+
+# Calculate new version
+case $BUMP_TYPE in
+  major)
+    NEW_MAJOR=$((MAJOR + 1))
+    NEW_MINOR=0
+    NEW_PATCH=0
+    ;;
+  minor)
+    NEW_MAJOR=$MAJOR
+    NEW_MINOR=$((MINOR + 1))
+    NEW_PATCH=0
+    ;;
+  patch)
+    NEW_MAJOR=$MAJOR
+    NEW_MINOR=$MINOR
+    NEW_PATCH=$((PATCH + 1))
+    ;;
+esac
+
+NEW_VERSION="$NEW_MAJOR.$NEW_MINOR.$NEW_PATCH"
+echo "🎯 New version would be: $NEW_VERSION"
+echo ""
+echo "✅ Version logic test completed successfully!"


### PR DESCRIPTION
- Revert version from 1.0.0 to 0.0.9 in Cargo.toml and Cargo.lock
- Clean up .gitignore by removing test-* pattern
- Enhance release workflow with better version bump logic
- Add test script for version bump logic validation